### PR TITLE
Fix 'repo settings copy' subcommand and support more repo settings

### DIFF
--- a/migrate/common/repos.py
+++ b/migrate/common/repos.py
@@ -106,6 +106,10 @@ class RepoSettings(DictData):
     default_branch: str = "main"
     visibility: RepoVisibility = RepoVisibility.PRIVATE
     ghas: GhasSettings = None
+    has_issues: bool = False
+    has_projects: bool = False
+    has_wiki: bool = False
+    has_pages: bool = False
 
     def __dict__(self):
         return self.to_dict()
@@ -218,6 +222,10 @@ def set_repo_settings(client: GhApi, org: str, repo: str, settings: RepoSettings
         allow_update_branch=settings.allow_update_branch,
         visibility=settings.visibility,
         security_and_analysis=settings.ghas.serialize(),
+        has_issues=settings.has_issues,
+        has_projects=settings.has_projects,
+        has_wiki=settings.has_wiki,
+        has_pages=settings.has_pages,
     )
 
     return RepoSettings.deserialize(result)

--- a/migrate/handlers/repo/settings.py
+++ b/migrate/handlers/repo/settings.py
@@ -64,11 +64,11 @@ def list_settings(ctx: TargetState, repo: str, output: click.File, compact: bool
 @click.option("-dr", "--dest", help="The destination repository")
 @migration_options
 @pass_migrationstate
-def copy_settings(ctx: MigrationState, src, dest, include_ghas):
+def copy_settings(ctx: MigrationState, src, dest):
     """Copies the settings from one repository to another"""
     src_client = create_client(hostname=ctx.src_hostname, token=ctx.src_token)
     dest_client = create_client(hostname=ctx.dest_hostname, token=ctx.dest_token)
-    src_settings = get_repo_settings(src_client, ctx.src_org, src, include_ghas)
+    src_settings = get_repo_settings(src_client, ctx.src_org, src)
     set_repo_settings(dest_client, ctx.dest_org, dest, src_settings)
 
 


### PR DESCRIPTION
## Changes
* Remove the unnecessary `include_ghas` para in functions handling repo setting copy;
* Support copying four more repo settings, i.e. `has_issues`, `has_projects`, `has_wiki`, `has_pages`


## Verification

### Before
```
> python3 -m migrate.main repo settings copy -c config.yml -sr abc -dr abc
Traceback (most recent call last):
...
TypeError: copy_settings() missing 1 required positional argument: 'include_ghas'
```

### After
```
python3 -m migrate.main repo settings copy -c config.yml -sr abc -dr abc
{
  "code": 404,
  "status": "Not Found",
  "context": "xxx",
  "details": {
    "message": "Not Found",
    "documentation_url": "xxx"
  }
}
```